### PR TITLE
fixed from PVS-Studio

### DIFF
--- a/src/PluginDefinition.cpp
+++ b/src/PluginDefinition.cpp
@@ -130,7 +130,7 @@ DWORD WINAPI ThreadProc(LPVOID lpParameter){
 			delete result;
 		}
 
-		delete pBuffer;
+		delete[] pBuffer;
 
 	}
 	else{
@@ -151,7 +151,7 @@ DWORD WINAPI ThreadProc(LPVOID lpParameter){
 			delete result;
 		}
 
-		delete pBuffer;
+		delete[] pBuffer;
 	}
 	return 0;
 }

--- a/src/URLCtrl.cpp
+++ b/src/URLCtrl.cpp
@@ -163,7 +163,7 @@ LRESULT URLCtrl::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 
 		    // Draw the text!
             TCHAR szWinText[_MAX_PATH];
-            ::GetWindowText(hwnd, szWinText, sizeof szWinText);
+            ::GetWindowText(hwnd, szWinText, sizeof szWinText / sizeof TCHAR);
             ::DrawText(hdc, szWinText, -1, &rect, dwDTStyle);
     		
             ::SelectObject(hdc, hOld);
@@ -211,7 +211,7 @@ LRESULT URLCtrl::runProc(HWND hwnd, UINT Message, WPARAM wParam, LPARAM lParam)
 			    else
 			    {
                     TCHAR szWinText[_MAX_PATH];
-                    ::GetWindowText(hwnd, szWinText, sizeof szWinText);
+                    ::GetWindowText(hwnd, szWinText, sizeof szWinText / sizeof TCHAR);
                     ::ShellExecute(NULL, _T("open"), szWinText, NULL, NULL, SW_SHOWNORMAL);
 			    }
 		    }


### PR DESCRIPTION
I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio. Warnings:

[V575](https://www.viva64.com/en/w/v575/) The number of processed elements should be passed to the 'GetWindowTextW' function as the third argument instead of buffer's size in bytes. urlctrl.cpp 166, 214
[V611](https://www.viva64.com/en/w/v611/) The memory was allocated using 'new T[]' operator but was released using the 'delete' operator. Consider inspecting this code. It's probably better to use 'delete [] pBuffer;'. plugindefinition.cpp 133, 154